### PR TITLE
Pin golangci-lint version to v1.64.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Minimum Go version
 GO_MIN_VERSION := 1.23.10
+LINT_VERSION := v1.64.5
 
 # Dynamically detect OS (e.g., darwin, linux) and architecture (amd64, arm64)
 GO_OS := $(shell uname -s | tr A-Z a-z)
@@ -35,18 +36,20 @@ install-tools: check-go-version
 	@echo "Installing other tools..."
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "🔧 Installing golangci-lint..."; \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5; \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(LINT_VERSION); \
 	else \
 		VERSION=$$(golangci-lint --version | awk '{print $$NF}'); \
-		if [[ "$${VERSION}" != "v1.64.5" ]]; then \
-			echo "🔄 Updating/Downgrading golangci-lint to v1.64.5..."; \
+		if [[ "$${VERSION}" != "$(LINT_VERSION)" ]]; then \
+			echo "🔄 Updating/Downgrading golangci-lint to $(LINT_VERSION)..."; \
 			go clean -i github.com/golangci/golangci-lint/cmd/golangci-lint; \
-			go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5; \
+			go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(LINT_VERSION); \
 		else \
-			echo "✅ golangci-lint v1.64.5 is already installed."; \
+			echo "✅ golangci-lint $(LINT_VERSION) is already installed."; \
 		fi; \
 	fi
 	@echo "✅ All tools installed successfully."
+
+
 
 # Linting target with a dependency on Go version check
 .PHONY: lint-fix

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install-tools: check-go-version
 		echo "🔧 Installing golangci-lint..."; \
 		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(LINT_VERSION); \
 	else \
-		VERSION=$$(golangci-lint --version | awk '{print $$NF}'); \
+		VERSION=$$(golangci-lint --version --format "{{.Version}}"); \
 		if [[ "$${VERSION}" != "$(LINT_VERSION)" ]]; then \
 			echo "🔄 Updating/Downgrading golangci-lint to $(LINT_VERSION)..."; \
 			go clean -i github.com/golangci/golangci-lint/cmd/golangci-lint; \

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,16 @@ install-tools: check-go-version
 	@echo "Installing other tools..."
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "🔧 Installing golangci-lint..."; \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5; \
 	else \
-		echo "✅ golangci-lint is already installed."; \
+		VERSION=$$(golangci-lint --version | awk '{print $$NF}'); \
+		if [[ "$${VERSION}" != "v1.64.5" ]]; then \
+			echo "🔄 Updating/Downgrading golangci-lint to v1.64.5..."; \
+			go clean -i github.com/golangci/golangci-lint/cmd/golangci-lint; \
+			go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5; \
+		else \
+			echo "✅ golangci-lint v1.64.5 is already installed."; \
+		fi; \
 	fi
 	@echo "✅ All tools installed successfully."
 


### PR DESCRIPTION
Ensures that golangci-lint is at the specific version v1.64.5.

This commit updates the Makefile to explicitly install and maintain golangci-lint at version v1.64.5. It checks if golangci-lint is already installed, and if so, verifies its version. If the version is different from v1.64.5, it updates or downgrades golangci-lint to the correct version.