### PR TITLE
Removes linting instruction from testing guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,6 @@
 ## Testing Instructions
 - Find the CI pipeline in the `.github/workflows` directory.
 - Fix any failing test before submitting a pull request `go test ./...` should pass with no errors.
-- Fix any linter issues before submitting a pull request by running `make lint`.
 - Add or update godoc comments for any new or modified functions, types, and packages.
 - Ensure that all new code is covered by tests. Use `go test -cover` to check coverage.
 - Add or update tests for the code you modify or add. 


### PR DESCRIPTION
The linting process is now integrated into the CI pipeline. This change removes the redundant instruction from the testing guidelines to avoid confusion.