### PR TITLE
[Feature] Enables Solidity installation on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,20 +38,36 @@ jobs:
       - name: Install golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.64.5/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin v1.64.5
       - run: $GITHUB_WORKSPACE/bin/golangci-lint run --config integration/golangci-lint.yml ./...
+
   unittest:
     name: Unit Tests
     strategy:
       fail-fast: false
       matrix:
         go-version:
-          - '1.23'
+          - '1.23' # Specify the Go version to use
     runs-on: ubuntu-latest
+    env:
+      SOLC_VERSION: '0.8.30' # Specify the Solidity compiler version
     steps:
       - name: Check Go Version
         uses: actions/setup-go@v4
         with:
           go-version: ${{matrix.go-version}}
+
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: Install solc-select (Python)
+        run: pip install solc-select
+
+      - name: Install and use Solidity
+        run: |
+          solc-select install $SOLC_VERSION
+          solc-select use $SOLC_VERSION
+          echo "$HOME/.solc-select/bin" >> $GITHUB_PATH
+          which solc
+          solc --version
+
       - name: Run tests
         run: make test

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ launcher := node.NewLauncher(logger)
 manager := node.NewNodeManager(logger, launcher, "./datadir", testutils.NewPort)
 ctx := context.Background()
 if err := manager.Start(ctx); err != nil {
-log.Fatal(err)
+    log.Fatal(err)
 }
 defer manager.Wait()
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,47 @@
 # Ethereum Go-native Local Network
-A fully Go-native tool to spin up and orchestrate a local Ethereum network composed of Geth and Prysm nodes — either in-process or inside Docker containers — without using Bash, Docker Compose, or non-Go tooling.
+
+A fully Go-native tool to spin up and orchestrate a local Ethereum network composed of Geth and Prysm nodes — either in-process or inside Docker
+containers — without using Bash, Docker Compose, or non-Go tooling.
 
 ## Prerequisites
 
-- **Go**: The project requires a minimum of **Go 1.23.10** or higher. You can download and install the required version
-  from [the official Go website](https://go.dev/dl/).
+### Golang
 
-Make sure you have the correct version installed by running:
+The project requires a minimum of **Go 1.23.10** or higher. You can download and install the required version
+from [the official Go website](https://go.dev/dl/). Make sure you have the correct version installed by running:
 
 ```bash
 go version
 ```
 
-If your Go version is lower than **1.23.10**, please upgrade your Go installation.# Ethereum Go-native Localnet
+If your Go version is lower than **1.23.10**, please upgrade your Go installation.
+
+### Solidity
+
+The project uses the Soldity compiler for smart contract development. You can install it using the following command:
+
+```bash
+brew install solidity
+```
+
+Ensure that the Solidity compiler is correctly installed by checking its version (should be at least `0.8.30+commit.73712a01`)
+
+```bash
+solc --version
+```
 
 ## 🎯 Goals
 
 - No shell scripts, YAML, or Makefiles
 - Pure Go orchestration: config, spawn, manage nodes
 - Support for both modes:
-  - **In-process**: embed Geth directly in Go
-  - **Dockerized**: use Go SDK to control containerized nodes
+    - **In-process**: embed Geth directly in Go
+    - **Dockerized**: use Go SDK to control containerized nodes
 - Compatible with full EL+CL setup (Geth + Prysm)
 
 -## 🚀 Features
 -
+
 - Launch a single Geth node on localhost
 - Blocks are produced using the simulated beacon
 - Programmatic control over ports and datadirs
@@ -47,7 +64,7 @@ launcher := node.NewLauncher(logger)
 manager := node.NewNodeManager(logger, launcher, "./datadir", testutils.NewPort)
 ctx := context.Background()
 if err := manager.Start(ctx); err != nil {
-    log.Fatal(err)
+log.Fatal(err)
 }
 defer manager.Wait()
 
@@ -55,6 +72,7 @@ fmt.Println("RPC listening on", manager.Handle().RpcPort())
 ```
 
 ## 🗺️ Roadmap
+
 - [x] Single Geth node (in-process)
 - [ ] Multi-node Geth network with peer connections
 - [ ] Docker-mode node runner (via Go SDK)
@@ -62,6 +80,7 @@ fmt.Println("RPC listening on", manager.Handle().RpcPort())
 - [ ] Config-driven topologies (mesh, star, etc.)
 
 ## Development
+
 ```makefile
 make lint # running linter
 make test # running tests

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If your Go version is lower than **1.23.10**, please upgrade your Go installatio
 
 ### Solidity
 
-The project uses the Soldity compiler for smart contract development. You can install it using the following command:
+The project uses the Solidity compiler for smart contract development. You can install it using the following command:
 
 ```bash
 brew install solidity


### PR DESCRIPTION
This PR enables Solidity installation at CI, a feature that we need for subsequent PRs to run Solidity-based tests on CI actions. Note that Solidity takes a bifurcated path on local vs CI installation. The installation is system dependent like Golang, hence `makefile` automation is not a viable and efficient approach. Hence, on local, we expect the user to install Solidty along with Golang as **prerequisites**. On CI that we have a more deterministic stable setup, we install it through `pip` package manager. 